### PR TITLE
fix: don't set default color field

### DIFF
--- a/src/geoms/interval/main.ts
+++ b/src/geoms/interval/main.ts
@@ -33,10 +33,8 @@ export default class IntervalParser extends ElementParser {
       if (_.isString(props.color)) {
         config.values = [props.color];
       } else if (_.isFunction(props.color)) {
-        config.fields = colorField;
         config.callback = props.color;
       } else if (_.isArray(props.color)) {
-        config.fields = colorField;
         config.values = props.color;
       }
     }
@@ -90,7 +88,6 @@ export default class IntervalParser extends ElementParser {
         return [props[m]];
       }
     }
-    return this.config.position.fields;
   }
 
   private _needParserColor() {


### PR DESCRIPTION
柱状图不使用默认position field作为color filed