### PR TITLE
fix: 允许label格式化时获取到原始数据点

### DIFF
--- a/src/components/label/parser.ts
+++ b/src/components/label/parser.ts
@@ -25,7 +25,7 @@ export default class LabelParser {
       config.position = labelProps.position;
     }
     if (labelProps.formatter) {
-      config.content = labelProps.formatter(val);
+      config.formatter = labelProps.formatter;
     }
     if (labelProps.style) {
       config.textStyle = labelProps.style;


### PR DESCRIPTION
在label parser中直接将formatter函数传入，