### PR TITLE
fix: auto padding for flipped legend

### DIFF
--- a/src/base/controller/padding.ts
+++ b/src/base/controller/padding.ts
@@ -92,7 +92,7 @@ export default class PaddingController {
       _.each(legends, (l) => {
         const legend = l as DataPointType;
         this._adjustLegend(legend, view, box);
-        const legendBBox = legend.get('container').getBBox();
+        const legendBBox = legend.getFlippedBBox();
         const { width, height } = legendBBox;
         let x = 0;
         let y = 0;


### PR DESCRIPTION
增加带翻页器的legend的auto padding处理逻辑，g2端修改见 https://github.com/antvis/g2/pull/1416